### PR TITLE
Reset `showFront` on exit

### DIFF
--- a/src/questions/QuestionModal.js
+++ b/src/questions/QuestionModal.js
@@ -32,7 +32,10 @@ const Fade = ({ children, ...props }) => (
 function QuestionModal({ overlayComponent, showModal, setShowModal }) {
   const [showFront, setShowFront] = useState(true);
 
-  const closeModal = () => setShowModal(false);
+  const closeModal = () => {
+    setShowModal(false);
+    setTimeout(() => setShowFront(true), 300);
+  }
 
   const btn = <CloseButton onClick={closeModal} />;
 


### PR DESCRIPTION
Проблема в том, что из-за `CSSTransition` после закрытия сбрасываются необходимые имена классов, из-за чего `showFront` и имена классов, отвечающие за анимацию, не синхронизированы между собой.
Данный фикс через 300 мс после закрытия окна выставляет дефолтное состояние карточки.

Closes #17.